### PR TITLE
Allowing a single variable to update best_bost

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub fn simulate_stream() {
 			best_rods.iteration = iterations;
 		}
 
-		if rods > best_both.rods && pearls > best_both.pearls {
+		if rods >= best_both.rods && pearls >= best_both.pearls {
 			best_both.pearls = pearls;
 			best_both.rods = rods;
 			best_both.iteration = iterations;


### PR DESCRIPTION
Currently both pearls and rods have to higher, now one being higher can update it.